### PR TITLE
CBPS-1556 Resolve pip deprecation warnings during perfrunner installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "setuptools_scm[toml]"
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mc_bin_client"
+version = "1.0.1"
+description = "Binary memcached client"
+
+[tool.setuptools]
+packages = [
+    "mc_bin_client",
+]
+include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,15 @@
 requires = [
     "setuptools",
     "wheel",
-    "setuptools_scm[toml]"
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "mc_bin_client"
 version = "1.0.1"
+authors = [
+    { name = "Dustin Sallings", email = "dustin@spy.net" },
+]
 description = "Binary memcached client"
 
 [tool.setuptools]

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,3 @@
 from setuptools import setup
 
-setup(
-    name='mc_bin_client',
-    version='1.0.1',
-    description='Binary memcached client',
-    author='Dustin Sallings',
-    author_email='dustin@spy.net',
-    packages=['mc_bin_client'],
-)
-
-#do smth
+setup()

--- a/setup.py
+++ b/setup.py
@@ -8,3 +8,5 @@ setup(
     author_email='dustin@spy.net',
     packages=['mc_bin_client'],
 )
+
+#do smth


### PR DESCRIPTION
Migrating from legacy setup.py to using pyproject.toml to get rid of deprecation warnings when running perfrunner.